### PR TITLE
fix register-middleware

### DIFF
--- a/src/FilamentLanguageSwitch.php
+++ b/src/FilamentLanguageSwitch.php
@@ -17,7 +17,6 @@ class FilamentLanguageSwitch
         $self = new static();
         $self->configure();
         $self->injectComponent();
-        $self->registerSwitchLanguageMiddleware();
     }
 
     public function injectComponent(): void
@@ -27,16 +26,5 @@ class FilamentLanguageSwitch
             'global-search.end',
             fn (): string => Blade::render("@livewire('switch-filament-language')")
         );
-    }
-
-    public function registerSwitchLanguageMiddleware(): void
-    {
-        if (! array_key_exists(
-            $key = SwitchLanguageLocale::class,
-            $filamentMiddlewares = config('filament.middleware.base')
-        )) {
-            $filamentMiddlewares[] = $key;
-            config(['filament.middleware.base' => $filamentMiddlewares]);
-        }
     }
 }

--- a/src/FilamentLanguageSwitchServiceProvider.php
+++ b/src/FilamentLanguageSwitchServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace BezhanSalleh\FilamentLanguageSwitch;
 
+use BezhanSalleh\FilamentLanguageSwitch\Http\Middleware\SwitchLanguageLocale;
 use Filament\Facades\Filament;
 use Filament\PluginServiceProvider;
 use Spatie\LaravelPackageTools\Package;
@@ -24,6 +25,18 @@ class FilamentLanguageSwitchServiceProvider extends PluginServiceProvider
 
     public function packageBooted(): void
     {
+        $this->registerSwitchLanguageMiddleware();
         Filament::serving(fn () => FilamentLanguageSwitch::boot());
+    }
+
+    public function registerSwitchLanguageMiddleware(): void
+    {
+        if (! array_key_exists(
+            $key = SwitchLanguageLocale::class,
+            $filamentMiddlewares = config('filament.middleware.base')
+        )) {
+            $filamentMiddlewares[] = $key;
+            config(['filament.middleware.base' => $filamentMiddlewares]);
+        }
     }
 }


### PR DESCRIPTION
### Problem

Service provider works in a different way for laravel serve and laravel octane
laravel serve to register service provider everytime. because each request do a complete bootstrap.
But octane once time (on startup application).

The middleware should be register once time on bootstrap application




### Solution
Moved the register middleware to `ServiceProvider`

### Notes
I tested with laravel serve and laravel octane with and without register migration on `config/filament.php`