### PR TITLE
allow panel wise configurations

### DIFF
--- a/resources/views/language-switch.blade.php
+++ b/resources/views/language-switch.blade.php
@@ -1,52 +1,70 @@
-<x-filament::dropdown teleport placement="bottom-end" class="fi-dropdown fi-user-menu">
-    <style>
-        .filament-dropdown-list-item-label {
-            display: flex;
-            justify-content: flex-start;
-            align-items: center;
-        }
-    </style>
-    <x-slot name="trigger" class="">
-        <div
-            class="flex items-center justify-center w-9 h-9 font-semibold text-sm text-white rounded-full language-switch-trigger bg-primary-500 dark:text-primary-500 dark:bg-gray-900 ring-1 ring-inset ring-gray-950/10 dark:ring-white/20">
-            {{ \Illuminate\Support\Str::of(app()->getLocale())->length() > 2
-                ? \Illuminate\Support\Str::of(app()->getLocale())->substr(0, 2)->upper()
-                : \Illuminate\Support\Str::of(app()->getLocale())->upper() }}
-        </div>
-    </x-slot>
-    <x-filament::dropdown.list class="!border-t-0">
-        @foreach (config('filament-language-switch.locales') as $key => $locale)
-            @if (!app()->isLocale($key))
-                <button type="button" class="fi-dropdown-list-item flex w-full items-center gap-2 whitespace-nowrap rounded-md p-2 text-sm transition-colors duration-75 outline-none disabled:pointer-events-none disabled:opacity-70 fi-dropdown-list-item-color-gray hover:bg-gray-950/5 focus:bg-gray-950/5 dark:hover:bg-white/5 dark:focus:bg-white/5" wire:click="changeLocale('{{ $key }}')">
+@php
+    $plugin = \BezhanSalleh\FilamentLanguageSwitch\FilamentLanguageSwitchPlugin::get();
 
-                    @if (config('filament-language-switch.flag'))
-                        <span>
+    $currentLocale = app()->currentLocale();
+    $shouldShowFlag = $plugin->shouldShowFlag();
+    $shouldShowNative = $plugin->shouldShowNative();
+    $locales = $plugin->getLocales();
+@endphp
+
+@if($plugin->shouldShowSelector())
+    <x-filament::dropdown teleport placement="bottom-end" class="fi-dropdown fi-user-menu">
+        <style>
+            .filament-dropdown-list-item-label {
+                display: flex;
+                justify-content: flex-start;
+                align-items: center;
+            }
+        </style>
+        <x-slot name="trigger" class="">
+            <div
+                class="flex items-center justify-center w-9 h-9 font-semibold text-sm text-white rounded-full language-switch-trigger bg-primary-500 dark:text-primary-500 dark:bg-gray-900 ring-1 ring-inset ring-gray-950/10 dark:ring-white/20">
+                {{ str($currentLocale)->length() > 2
+                    ? str($currentLocale)->substr(0, 2)->upper()
+                    : str($currentLocale)->upper() }}
+            </div>
+        </x-slot>
+        <x-filament::dropdown.list class="!border-t-0">
+            @foreach ($locales as $key => $locale)
+                @if (!app()->isLocale($key))
+                    <button type="button" class="fi-dropdown-list-item flex w-full items-center gap-2 whitespace-nowrap rounded-md p-2 text-sm transition-colors duration-75 outline-none disabled:pointer-events-none disabled:opacity-70 fi-dropdown-list-item-color-gray hover:bg-gray-950/5 focus:bg-gray-950/5 dark:hover:bg-white/5 dark:focus:bg-white/5" wire:click="changeLocale('{{ $key }}')">
+
+                        @if ($shouldShowFlag)
+                            <span>
                             <x-dynamic-component :component="'flag-1x1-' . (!blank($locale['flag_code']) ? $locale['flag_code'] : 'un')"
-                                class="flex-shrink-0 w-5 h-5 group-hover:text-white group-focus:text-white text-primary-500"
-                                style="border-radius: 0.25rem" />
+                                                 class="flex-shrink-0 w-5 h-5 group-hover:text-white group-focus:text-white text-primary-500"
+                                                 style="border-radius: 0.25rem" />
                         </span>
-                    @else
-                        <span
-                            class="w-6 h-6 flex items-center justify-center flex-shrink-0 @if (!app()->isLocale($key)) group-hover:bg-white group-hover:text-primary-600 group-hover:border group-hover:border-primary-500/10 group-focus:text-white @endif bg-primary-500/10 text-primary-500 font-semibold rounded-full p-4 text-xs">
+                        @else
+                            <span
+                                class="w-6 h-6 flex items-center justify-center flex-shrink-0 @if (!app()->isLocale($key)) group-hover:bg-white group-hover:text-primary-600 group-hover:border group-hover:border-primary-500/10 group-focus:text-white @endif bg-primary-500/10 text-primary-500 font-semibold rounded-full p-4 text-xs">
                             {{ \Illuminate\Support\Str::of($locale['name'])->snake()->upper()->explode('_')->map(function ($string) use ($locale) {
                                     return \Illuminate\Support\Str::of($locale['name'])->wordCount() > 1 ? \Illuminate\Support\Str::substr($string, 0, 1) : \Illuminate\Support\Str::substr($string, 0, 2);
                                 })->take(2)->implode('') }}
                         </span>
-                    @endif
-                    <span class="hover:bg-transparent text-gray-700 dark:text-gray-200">
-                        {{ \Illuminate\Support\Str::of($locale[config('filament-language-switch.native') ? 'native' : 'name'])->headline() }}
+                        @endif
+                        <span class="hover:bg-transparent text-gray-700 dark:text-gray-200">
+                        {{ \Illuminate\Support\Str::of($locale[$shouldShowNative ? 'native' : 'name'])->headline() }}
                     </span>
-                </button>
-            @endif
-        @endforeach
+                    </button>
+                @endif
+            @endforeach
 
-    </x-filament::dropdown.list>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            window.addEventListener('filament-language-changed', () => {
-                console.log('Language changed');
-                location.reload(true);
-            });
-        })
-    </script>
-</x-filament::dropdown>
+        </x-filament::dropdown.list>
+        <script>
+            document.addEventListener('DOMContentLoaded', () => {
+                window.addEventListener('filament-language-changed', () => {
+                    console.log('Language changed');
+                    location.reload(true);
+                });
+            })
+        </script>
+    </x-filament::dropdown>
+@else
+    <div
+        class="flex items-center justify-center w-9 h-9 font-semibold text-sm text-white rounded-full language-switch-trigger bg-primary-500 dark:text-primary-500 dark:bg-gray-900 ring-1 ring-inset ring-gray-950/10 dark:ring-white/20">
+        {{ str($currentLocale)->length() > 2
+            ? str($currentLocale)->substr(0, 2)->upper()
+            : str($currentLocale)->upper() }}
+    </div>
+@endif

--- a/src/FilamentLanguageSwitchPlugin.php
+++ b/src/FilamentLanguageSwitchPlugin.php
@@ -6,6 +6,7 @@ use BezhanSalleh\FilamentLanguageSwitch\Http\Livewire\SwitchFilamentLanguage;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\Configurable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
 
@@ -14,6 +15,12 @@ class FilamentLanguageSwitchPlugin implements Plugin
     use Configurable;
 
     protected string $renderHookName = 'panels::global-search.after';
+
+    protected ?bool $native = null;
+
+    protected ?bool $flag = null;
+
+    protected ?array $locales = null;
 
     public static function make(): static
     {
@@ -54,6 +61,54 @@ class FilamentLanguageSwitchPlugin implements Plugin
                 name: $this->getRenderHookName(),
                 hook: fn (): string => Blade::render('@livewire(\'switch-filament-language\')')
             );
+    }
+
+    public function shouldShowSelector(): bool
+    {
+        $locales = $this->getLocales();
+
+        return count($locales) > 1 || ! array_key_exists(app()->currentLocale(), $locales);
+    }
+
+    public function native(bool $enabled = true): self
+    {
+        $this->native = $enabled;
+
+        return $this;
+    }
+
+    public function shouldShowNative(): bool
+    {
+        return is_null($this->native) ? config('filament-language-switch.native') : $this->native;
+    }
+
+    public function flag(bool $enabled = true): self
+    {
+        $this->flag = $enabled;
+
+        return $this;
+    }
+
+    public function shouldShowFlag(): bool
+    {
+        return is_null($this->flag) ? config('filament-language-switch.flag') : $this->flag;
+    }
+
+    public function locales(array $allowedLocales): self
+    {
+        $this->locales = $allowedLocales;
+
+        return $this;
+    }
+
+    public function getLocales(): array
+    {
+        $locales = config('filament-language-switch.locales');
+
+        if (! is_null($this->locales)) {
+            $locales = Arr::only($locales, $this->locales);
+        }
+        return $locales;
     }
 
     public function boot(Panel $panel): void


### PR DESCRIPTION
With this PR, now this plugin can have different configurations for each panels. by default this will get config values from global config file. However we can override those config panel wise while declaring plugin for each panel.

For example, we can config flag/native/locales for particular panel only using

```PHP
FilamentLanguageSwitchPlugin::make()
    ->native()
    ->flag()
    ->locales(['en', 'hi', 'ta'])
```