### PR TITLE
Add Laravel event to catch locale change in your own application

### DIFF
--- a/src/Events/LocaleChanged.php
+++ b/src/Events/LocaleChanged.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BezhanSalleh\FilamentLanguageSwitch\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LocaleChanged
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public string $locale)
+    {
+    }
+}

--- a/src/Http/Livewire/FilamentLanguageSwitch.php
+++ b/src/Http/Livewire/FilamentLanguageSwitch.php
@@ -2,6 +2,7 @@
 
 namespace BezhanSalleh\FilamentLanguageSwitch\Http\Livewire;
 
+use BezhanSalleh\FilamentLanguageSwitch\Events\LocaleChanged;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
@@ -13,7 +14,9 @@ class FilamentLanguageSwitch extends Component
 
         cookie()->queue(cookie()->forever('filament_language_switch_locale', $locale));
 
-        $this->dispatch('filament-language-changed', $locale);
+        $this->dispatch('filament-language-changed');
+
+        LocaleChanged::dispatch($locale);
 
         $this->redirect(request()->header('Referer'));
 

--- a/src/Http/Livewire/FilamentLanguageSwitch.php
+++ b/src/Http/Livewire/FilamentLanguageSwitch.php
@@ -13,7 +13,7 @@ class FilamentLanguageSwitch extends Component
 
         cookie()->queue(cookie()->forever('filament_language_switch_locale', $locale));
 
-        $this->dispatch('filament-language-changed');
+        $this->dispatch('filament-language-changed', $locale);
 
         $this->redirect(request()->header('Referer'));
 

--- a/src/Http/Middleware/SwitchLanguageLocale.php
+++ b/src/Http/Middleware/SwitchLanguageLocale.php
@@ -4,22 +4,17 @@ namespace BezhanSalleh\FilamentLanguageSwitch\Http\Middleware;
 
 use BezhanSalleh\FilamentLanguageSwitch\LanguageSwitch;
 use Closure;
-use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 
 class SwitchLanguageLocale
 {
     public function handle(Request $request, Closure $next): \Illuminate\Http\Response | \Illuminate\Http\RedirectResponse
     {
-        if (Filament::auth()->check()) {
-            $locale = Filament::auth()->user()->language;
-        } else {
-            $locale = session()->get('locale')
-                ?? $request->get('locale')
-                ?? $request->cookie('filament_language_switch_locale')
-                ?? $this->getBrowserLocale($request)
-                ?? config('app.locale', 'en');
-        }
+        $locale = session()->get('locale')
+            ?? $request->get('locale')
+            ?? $request->cookie('filament_language_switch_locale')
+            ?? $this->getBrowserLocale($request)
+            ?? config('app.locale', 'en');
 
         if (in_array($locale, LanguageSwitch::make()->getLocales())) {
             app()->setLocale($locale);

--- a/src/Http/Middleware/SwitchLanguageLocale.php
+++ b/src/Http/Middleware/SwitchLanguageLocale.php
@@ -4,17 +4,22 @@ namespace BezhanSalleh\FilamentLanguageSwitch\Http\Middleware;
 
 use BezhanSalleh\FilamentLanguageSwitch\LanguageSwitch;
 use Closure;
+use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 
 class SwitchLanguageLocale
 {
     public function handle(Request $request, Closure $next): \Illuminate\Http\Response | \Illuminate\Http\RedirectResponse
     {
-        $locale = session()->get('locale')
-            ?? $request->get('locale')
-            ?? $request->cookie('filament_language_switch_locale')
-            ?? $this->getBrowserLocale($request)
-            ?? config('app.locale', 'en');
+        if (Filament::auth()->check()) {
+            $locale = Filament::auth()->user()->language;
+        } else {
+            $locale = session()->get('locale')
+                ?? $request->get('locale')
+                ?? $request->cookie('filament_language_switch_locale')
+                ?? $this->getBrowserLocale($request)
+                ?? config('app.locale', 'en');
+        }
 
         if (in_array($locale, LanguageSwitch::make()->getLocales())) {
             app()->setLocale($locale);


### PR DESCRIPTION
The package is good to change the language in the browser, but we want to save the users locale in the database. Currently that's not possible.

We introduce a Laravel event that gets dispatched when the locale is changed.

In your own application you can listen for this event and add your own listener that uses the locale string to save it in the database like this:

In the EventServiceProvider
```php
    protected $listen = [
        LocaleChanged::class => [
            UserChangedLocale::class,
        ],
    ];
```

and in the listener
```php

    public function handle(object $event): void
    {
        Filament::auth()->user()->update(['locale' => $event->locale]);
    }

```

To load the users locale in your application you can add your own middleware to the panel providers where you set the locale from the database

```php
    public function handle(Request $request, Closure $next): Response
    {
        if (filament()->auth()->check()) {
            app()->setLocale(filament()->auth()->user()->locale);
        }

        return $next($request);
    }
```