### PR TITLE
Get the default local from the Laravel config file before the browser

### DIFF
--- a/src/Http/Middleware/SwitchLanguageLocale.php
+++ b/src/Http/Middleware/SwitchLanguageLocale.php
@@ -17,6 +17,7 @@
 				?? $request->cookie('filament_language_switch_locale')
 				?? config('app.locale' , 'en')
 				?? $this->getBrowserLocale($request);
+			
 			if (in_array($locale , LanguageSwitch::make()->getLocales())) {
 				app()->setLocale($locale);
 			}

--- a/src/Http/Middleware/SwitchLanguageLocale.php
+++ b/src/Http/Middleware/SwitchLanguageLocale.php
@@ -1,40 +1,41 @@
 <?php
-
-namespace BezhanSalleh\FilamentLanguageSwitch\Http\Middleware;
-
-use BezhanSalleh\FilamentLanguageSwitch\LanguageSwitch;
-use Closure;
-use Illuminate\Http\Request;
-
-class SwitchLanguageLocale
-{
-    public function handle(Request $request, Closure $next): \Illuminate\Http\Response | \Illuminate\Http\RedirectResponse
-    {
-        $locale = session()->get('locale')
-            ?? $request->get('locale')
-            ?? $request->cookie('filament_language_switch_locale')
-            ?? $this->getBrowserLocale($request)
-            ?? config('app.locale', 'en');
-
-        if (in_array($locale, LanguageSwitch::make()->getLocales())) {
-            app()->setLocale($locale);
-        }
-
-        return $next($request);
-    }
-
-    private function getBrowserLocale(Request $request): ?string
-    {
-        $appLocales = LanguageSwitch::make()->getLocales();
-
-        $userLocales = preg_split('/[,;]/', $request->server('HTTP_ACCEPT_LANGUAGE'));
-
-        foreach ($userLocales as $locale) {
-            if (in_array($locale, $appLocales)) {
-                return $locale;
-            }
-        }
-
-        return null;
-    }
-}
+	
+	namespace BezhanSalleh\FilamentLanguageSwitch\Http\Middleware;
+	
+	use BezhanSalleh\FilamentLanguageSwitch\LanguageSwitch;
+	use Closure;
+	use Illuminate\Http\RedirectResponse;
+	use Illuminate\Http\Request;
+	use Illuminate\Http\Response;
+	
+	class SwitchLanguageLocale
+	{
+		public function handle(Request $request , Closure $next): Response|RedirectResponse
+		{
+			$locale = session()->get('locale')
+				?? $request->get('locale')
+				?? $request->cookie('filament_language_switch_locale')
+				?? config('app.locale' , 'en')
+				?? $this->getBrowserLocale($request);
+			if (in_array($locale , LanguageSwitch::make()->getLocales())) {
+				app()->setLocale($locale);
+			}
+			
+			return $next($request);
+		}
+		
+		private function getBrowserLocale(Request $request): ?string
+		{
+			$appLocales = LanguageSwitch::make()->getLocales();
+			
+			$userLocales = preg_split('/[,;]/' , $request->server('HTTP_ACCEPT_LANGUAGE'));
+			
+			foreach ($userLocales as $locale) {
+				if (in_array($locale , $appLocales)) {
+					return $locale;
+				}
+			}
+			
+			return null;
+		}
+	}


### PR DESCRIPTION
To follow Laravel way If I want to start my app using the  `config('app.locale')`  by Editing the app file in config directory
```
'locale' => 'ar',
```
Then we must put this line 
```
?? config('app.locale', 'en');
```

above this line
```
$this->getBrowserLocale($request)
```

then the final result in the `SwitchLanguageLocale` Middleware is
```
$locale = session()->get('locale')
				?? $request->get('locale')
				?? $request->cookie('filament_language_switch_locale')
				?? config('app.locale' , 'en')
				?? $this->getBrowserLocale($request);
```