### PR TITLE
partial fix for placement

### DIFF
--- a/resources/views/language-switch.blade.php
+++ b/resources/views/language-switch.blade.php
@@ -16,7 +16,7 @@
 <div>
     @if ($isVisibleOutsidePanels)
         <div @class([
-            'fls-display-on fixed w-fit flex p-4 z-50',
+            'fls-display-on fixed w-full flex p-4',
             'top-0' => str_contains($outsidePanelsPlacement, 'top'),
             'bottom-0' => str_contains($outsidePanelsPlacement, 'bottom'),
             'justify-start' => str_contains($outsidePanelsPlacement, 'left'),


### PR DESCRIPTION
partial fix for #90 

**Another problem:** If I use `Placement::TopRight` then the noti/account and lang-swith are place on top of each other (only on profile page) like this image
![Screenshot from 2024-04-09 11-24-00](https://github.com/bezhanSalleh/filament-language-switch/assets/28250303/cf4d1c33-b496-473d-9a2b-c77d792becbc)

I cannot run/install tailwind and it's dependencies because of below error (but I don't know how to fix for now) so I cannot check more. Bezhan, as you said in discord I've submitted this PR in order to look further from you

The error
![Screenshot from 2024-04-09 11-46-51](https://github.com/bezhanSalleh/filament-language-switch/assets/28250303/fc5e638e-b316-44c8-b6f5-f4b3cc78fef5)


My guess for fixing this is to put like this
```diff
<div @class([
    ...
    '-right-5' => str_contains($outsidePanelsPlacement, 'top-right') // may need to check if it's profile cause others are working fine
])>
```


If this PR is not the right fix then feel free to close it