### PR TITLE
Fixes dropdown placement outside panels

### DIFF
--- a/resources/views/language-switch.blade.php
+++ b/resources/views/language-switch.blade.php
@@ -16,7 +16,7 @@
 <div>
     @if ($isVisibleOutsidePanels)
         <div @class([
-            'fls-display-on fixed w-fit flex p-4 z-50',
+            'fls-display-on fixed w-full flex p-4 z-50',
             'top-0' => str_contains($outsidePanelsPlacement, 'top'),
             'bottom-0' => str_contains($outsidePanelsPlacement, 'bottom'),
             'justify-start' => str_contains($outsidePanelsPlacement, 'left'),


### PR DESCRIPTION
Currently the panel switcher on authentication pages only works in the top left. Updating the `w-fit` class to `w-full` fixes this behavior.