### PR TITLE
Add max height to language switch dropdown

### DIFF
--- a/resources/views/language-switch.blade.php
+++ b/resources/views/language-switch.blade.php
@@ -12,6 +12,7 @@
         ! $isVisibleOutsidePanels && $isFlagsOnly=> 'bottom',
         default => 'bottom-end',
     };
+    $maxHeight = $languageSwitch->getMaxHeight();
 @endphp
 <div>
     @if ($isVisibleOutsidePanels)

--- a/resources/views/switch.blade.php
+++ b/resources/views/switch.blade.php
@@ -2,6 +2,7 @@
     teleport
     :placement="$placement"
     :width="$isFlagsOnly ? 'flags-only' : 'fls-dropdown-width'"
+    :max-height="$maxHeight"
     class="fi-dropdown fi-user-menu"
 >
     <x-slot name="trigger">

--- a/src/LanguageSwitch.php
+++ b/src/LanguageSwitch.php
@@ -39,6 +39,8 @@ class LanguageSwitch extends Component
 
     protected bool | Closure $visibleOutsidePanels = false;
 
+    protected string $maxHeight = 'max-content';
+
     protected Closure | string $renderHook = 'panels::global-search.after';
 
     protected Closure | string | null $userPreferredLocale = null;
@@ -174,6 +176,13 @@ class LanguageSwitch extends Component
         return $this;
     }
 
+    public function maxHeight(string $height): static
+    {
+        $this->maxHeight = $height;
+
+        return $this;
+    }
+
     public function getDisplayLocale(): ?string
     {
         return $this->evaluate($this->displayLocale);
@@ -268,6 +277,11 @@ class LanguageSwitch extends Component
             request()->getPreferredLanguage();
 
         return in_array($locale, $this->getLocales(), true) ? $locale : config('app.locale');
+    }
+
+    public function getMaxHeight(): string
+    {
+        return $this->maxHeight;
     }
 
     /**


### PR DESCRIPTION
We would like to add the functionality to set the max height of the dropdown. Because when you have a lot of languages you can't scroll through the list anymore

It currently looks like this
<img width="355" alt="image" src="https://github.com/bezhanSalleh/filament-language-switch/assets/2892138/14c0fe5f-5651-4762-a523-2edd5431ea4b">

and like this with the PR
<img width="332" alt="Bildschirmfoto 2024-06-18 um 09 44 54" src="https://github.com/bezhanSalleh/filament-language-switch/assets/2892138/e165d10a-a51d-45a5-8459-85c34db6a6ea">
