### PR TITLE
Make route getName optional

### DIFF
--- a/src/LanguageSwitch.php
+++ b/src/LanguageSwitch.php
@@ -224,7 +224,7 @@ class LanguageSwitch extends Component
     public function isVisibleOutsidePanels(): bool
     {
         return (bool) ($this->evaluate($this->visibleOutsidePanels)
-            && str(request()->route()->getName())->contains($this->outsidePanelRoutes)
+            && str(request()->route()?->getName())->contains($this->outsidePanelRoutes)
             && $this->isCurrentPanelIncluded());
     }
 


### PR DESCRIPTION
Since 404 routes return `null` this breaks calling `getName()`. Adding `?` fixes this