### PR TITLE
add data-nosnippet to language switcher dropdown

### DIFF
--- a/resources/views/switch.blade.php
+++ b/resources/views/switch.blade.php
@@ -4,6 +4,7 @@
     :width="$isFlagsOnly ? 'flags-only' : 'fls-dropdown-width'"
     :max-height="$maxHeight"
     class="fi-dropdown fi-user-menu"
+    data-nosnippet="true"
 >
     <x-slot name="trigger">
         <div


### PR DESCRIPTION
This prevents Google using this language switcher for their snippet.

for example:
![CleanShot 2025-05-30 at 01 53 20@2x](https://github.com/user-attachments/assets/e3751062-1b09-4ca1-a516-82fa5bd6a785)
