### PR TITLE
Function to set cookiename is missing  #165

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Zero-config language switching for Filament Panels. Drop it in, provide your loc
 - [Inline Embedding](#inline-embedding-in-custom-pages)
 - [Panel Exclusion](#panel-exclusion)
 - [User Preferred Locale](#user-preferred-locale)
+- [Cookie Name](#cookie-name)
 - [Customization](#customization)
 - [Event](#event)
 - [Control Panel](#control-panel)
@@ -488,6 +489,16 @@ The locale resolution order is:
 5. Cookie
 6. `app.locale` config
 
+## Cookie Name
+
+The selected locale is remembered in a forever cookie. Rename it if it collides with a cookie your app already uses:
+
+```php
+$switch->cookieName('my_app_locale');
+```
+
+Defaults to `filament_language_switch_locale`. If you need to read the cookie outside of Laravel (in JavaScript, for example), add the same name to the `$except` list of your `EncryptCookies` middleware.
+
 ## Customization
 
 For deep customization, publish the plugin's views and edit them in your app:
@@ -583,7 +594,8 @@ LanguageSwitch::configureUsing(function (LanguageSwitch $switch) {
             icon: Heroicon::GlobeAlt,
         )
         ->excludes(['admin'])
-        ->userPreferredLocale(fn () => auth()->user()?->locale);
+        ->userPreferredLocale(fn () => auth()->user()?->locale)
+        ->cookieName('my_app_locale');
 });
 ```
 

--- a/src/Concerns/HasLocales.php
+++ b/src/Concerns/HasLocales.php
@@ -22,6 +22,8 @@ trait HasLocales
 
     protected string | Closure | null $userPreferredLocale = null;
 
+    protected string | Closure $cookieName = 'filament_language_switch_locale';
+
     public function locales(array | Closure $locales): static
     {
         $this->locales = $locales;
@@ -60,6 +62,13 @@ trait HasLocales
     public function userPreferredLocale(Closure | string | null $locale): static
     {
         $this->userPreferredLocale = $locale;
+
+        return $this;
+    }
+
+    public function cookieName(string | Closure $name): static
+    {
+        $this->cookieName = $name;
 
         return $this;
     }
@@ -105,13 +114,18 @@ trait HasLocales
         return $this->evaluate($this->userPreferredLocale);
     }
 
+    public function getCookieName(): string
+    {
+        return (string) $this->evaluate($this->cookieName);
+    }
+
     public function getPreferredLocale(): string
     {
         $locale = session()->get('locale') ??
             request()->query('locale') ??
             $this->getUserPreferredLocale() ??
             request()->getPreferredLanguage($this->getLocales()) ??
-            request()->cookie('filament_language_switch_locale') ??
+            request()->cookie($this->getCookieName()) ??
             config('app.locale');
 
         return in_array($locale, $this->getLocales(), true) ? $locale : config('app.locale');
@@ -149,7 +163,7 @@ trait HasLocales
     {
         session()->put('locale', $locale);
 
-        cookie()->queue(cookie()->forever('filament_language_switch_locale', $locale));
+        cookie()->queue(cookie()->forever(static::make()->getCookieName(), $locale));
 
         event(new LocaleChanged($locale));
     }

--- a/tests/CookieNameTest.php
+++ b/tests/CookieNameTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use BezhanSalleh\LanguageSwitch\LanguageSwitch;
+
+it('falls back to the original cookie name', function () {
+    expect(LanguageSwitch::make()->getCookieName())
+        ->toBe('filament_language_switch_locale');
+});
+
+it('can override the cookie name', function () {
+    expect(LanguageSwitch::make()->cookieName('my_app_locale')->getCookieName())
+        ->toBe('my_app_locale');
+});
+
+it('evaluates a closure cookie name', function () {
+    expect(LanguageSwitch::make()->cookieName(fn (): string => 'closure_locale')->getCookieName())
+        ->toBe('closure_locale');
+});
+
+it('applies the cookie name configured via configureUsing', function () {
+    LanguageSwitch::configureUsing(fn (LanguageSwitch $switch) => $switch->cookieName('configured_locale'));
+
+    expect(LanguageSwitch::make()->getCookieName())
+        ->toBe('configured_locale');
+});


### PR DESCRIPTION
The locale cookie name was hardcoded as `filament_language_switch_locale` in
`HasLocales` the only setting in the plugin that could not be changed. This adds
a `cookieName()` setting that follows the same pattern as every other setting, and
defaults to the current name so nothing changes for existing installations.

```php
LanguageSwitch::configureUsing(function (LanguageSwitch $switch) {
    $switch
        ->locales(['en', 'nl', 'de'])
        ->cookieName('my_app_locale');
});
```
#165

I created a test to check whether the old cookie is still valid.